### PR TITLE
chore: align web.xml with canonical formatting

### DIFF
--- a/src/main/resources/webapp/fake-services-admin/WEB-INF/web.xml
+++ b/src/main/resources/webapp/fake-services-admin/WEB-INF/web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
          version="6.1">
-
     <display-name>fake-services-admin</display-name>
 
     <filter>

--- a/src/main/resources/webapp/fake-services/WEB-INF/web.xml
+++ b/src/main/resources/webapp/fake-services/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
          version="6.1">
     <display-name>fake-services</display-name>
 


### PR DESCRIPTION
Standardizes every `web.xml` descriptor on the canonical `aad-synchronizer`
formatting so all extensions share an identical header and indentation style.

### Changes
- `web-app` header attribute order: `xmlns` before `xmlns:xsi`, with the
  `schemaLocation` continuation aligned under the namespace URI (the Siemens
  2606 canonical header)
- 4-space indentation, no tabs
- no blank line between the header and the first body element

Formatting only -- no functional change. The Jakarta schema
(`web-app_6_1.xsd`, `version="6.1"`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
